### PR TITLE
updated to fix issue around empty description or summary

### DIFF
--- a/scripts/jira-lookup.coffee
+++ b/scripts/jira-lookup.coffee
@@ -29,10 +29,10 @@ module.exports = (robot) ->
         try
           json = JSON.parse(body)
           json_summary = ""
-          unless json.fields.summary.nil? or json.fields.summary.empty?
+          unless json.fields.summary is null or json.fields.summary.nil? or json.fields.summary.empty?
               json_summary = json.fields.summary
           json_description = ""
-          unless json.fields.description.nil? or json.fields.description.empty?
+          unless json.fields.description is null or json.fields.description.nil? or json.fields.description.empty?
               desc_array = json.fields.description.split("\n")
               json_description = ""
               for item in desc_array[0..2]


### PR DESCRIPTION
we found that when a user entered a simple ticket that needed only
a subject like "please create my jenkins account" with no further
description it would cause the lookup to fail
