### PR TITLE
test for existance of fields

### DIFF
--- a/scripts/jira-lookup.coffee
+++ b/scripts/jira-lookup.coffee
@@ -3,7 +3,7 @@
 #
 # Dependencies:
 #   None
-# 
+#
 # Configuration:
 #   HUBOT_JIRA_LOOKUP_USERNAME
 #   HUBOT_JIRA_LOOKUP_PASSWORD
@@ -29,22 +29,28 @@ module.exports = (robot) ->
         try
           json = JSON.parse(body)
           json_summary = ""
-          unless json.fields.summary is null or json.fields.summary.nil? or json.fields.summary.empty?
-              json_summary = json.fields.summary
+          if json.fields.summary
+              unless json.fields.summary is null or json.fields.summary.nil? or json.fields.summary.empty?
+                  json_summary = json.fields.summary
           json_description = ""
-          unless json.fields.description is null or json.fields.description.nil? or json.fields.description.empty?
-              desc_array = json.fields.description.split("\n")
-              json_description = ""
-              for item in desc_array[0..2]
-                  json_description += item
-          json_assignee = "[unassigned]"
-          unless json.fields.assignee is null or json.fields.assignee.nil? or json.fields.assignee.empty?
-              unless json.fields.assignee.name.nil? or json.fields.assignee.name.empty?
-                  json_assignee = json.fields.assignee.name
+          if json.fields.description
+              json_description = "\n Description: "
+              unless json.fields.description is null or json.fields.description.nil? or json.fields.description.empty?
+                  desc_array = json.fields.description.split("\n")
+                  for item in desc_array[0..2]
+                      json_description += item
+          json_assignee = ""
+          if json.fields.assignee
+              json_assignee = "\n Assignee:    "
+              unless json.fields.assignee is null or json.fields.assignee.nil? or json.fields.assignee.empty?
+                  unless json.fields.assignee.name.nil? or json.fields.assignee.name.empty?
+                      json_assignee += json.fields.assignee.name
           json_status = ""
-          unless json.fields.status is null or json.fields.status.nil? or json.fields.status.empty?
-              unless json.fields.status.name.nil? or json.fields.status.name.empty?
-                  json_status = json.fields.status.name
-          msg.send "Issue:       #{json.key}: #{json_summary}\n Description: #{json_description}\n Assignee:    #{json_assignee}\n Status:      #{json_status}\n Link:        #{process.env.HUBOT_JIRA_LOOKUP_URL}/browse/#{json.key}\n"
+          if json.fields.status
+              json_status = "\n Status:      "
+              unless json.fields.status is null or json.fields.status.nil? or json.fields.status.empty?
+                  unless json.fields.status.name.nil? or json.fields.status.name.empty?
+                      json_status += json.fields.status.name
+          msg.send "Issue:       #{json.key}: #{json_summary}#{json_description}#{json_assignee}#{json_status}\n Link:        #{process.env.HUBOT_JIRA_LOOKUP_URL}/browse/#{json.key}\n"
         catch error
           msg.send "*sinister laugh*"


### PR DESCRIPTION
Some jira workflows remove one or more of these fields, causing:

  TypeError: Cannot read property 'nil' of undefined

Which gets caught and ends up as a _sinister laugh_...even though it could have been so much more.
