### PR TITLE
A more judicious lookup

### DIFF
--- a/scripts/jira-lookup.coffee
+++ b/scripts/jira-lookup.coffee
@@ -17,7 +17,7 @@
 #   Benjamin Sherman  <benjamin@jivesoftware.com> (http://www.jivesoftware.com)
 
 module.exports = (robot) ->
-  robot.hear /(^|\s)[a-zA-Z]{2,5}-[0-9]{1,5}($|\s)/, (msg) ->
+  robot.hear /(?:^|\s)[a-zA-Z]{2,5}-[0-9]{1,5}(?:$|\s)/, (msg) ->
     issue = msg.match[0]
     user = process.env.HUBOT_JIRA_LOOKUP_USERNAME
     pass = process.env.HUBOT_JIRA_LOOKUP_PASSWORD


### PR DESCRIPTION
In using this wonderfully handy script, we noticed it got a little jumpy anytime a word-hyphen-number combo was used, regardless of much of anything. The sinister chuckling got to be too much, so we made the regex a bit stricter. Now, seems to be working well and hubot is a little more friendly yet again. :grinning:
