### PR TITLE
Using \b around robot.hear regex, to capture a wider variety of valid cases.

### DIFF
--- a/scripts/jira-lookup.coffee
+++ b/scripts/jira-lookup.coffee
@@ -17,7 +17,7 @@
 #   Benjamin Sherman  <benjamin@jivesoftware.com> (http://www.jivesoftware.com)
 
 module.exports = (robot) ->
-  robot.hear /(?:^|\s)[a-zA-Z]{2,5}-[0-9]{1,5}(?:$|\s)/, (msg) ->
+  robot.hear /\b[a-zA-Z]{2,5}-[0-9]{1,5}\b/, (msg) ->
     issue = msg.match[0]
     user = process.env.HUBOT_JIRA_LOOKUP_USERNAME
     pass = process.env.HUBOT_JIRA_LOOKUP_PASSWORD


### PR DESCRIPTION
Following on from #6, we found using `\b` around the regex provided better coverage of different use cases.

E.g. this will now match JIRA issue numbers surrounded by punctuation marks, whitespace and line endings, as shown [here](http://regexr.com/38o6q).

Thanks! :grin: 
