### PR TITLE
Add option to ignore certification verification errors

### DIFF
--- a/scripts/jira-lookup.coffee
+++ b/scripts/jira-lookup.coffee
@@ -131,7 +131,10 @@ reportIssue = (robot, msg, issue) ->
 
     auth = 'Basic ' + new Buffer(user + ':' + pass).toString('base64')
 
-    robot.http("#{url}/rest/api/latest/issue/#{issue}")
+    options = {}
+    if process.env.HUBOT_JIRA_LOOKUP_ALLOW_UNAUTHORIZED
+        options['rejectUnauthorized'] = false;
+    robot.http("#{url}/rest/api/latest/issue/#{issue}", options)
       .headers(Authorization: auth, Accept: 'application/json')
       .get() (err, res, body) ->
         try


### PR DESCRIPTION
Add the option: HUBOT_JIRA_LOOKUP_ALLOW_UNAUTHORIZED

If it is set to true, ignore SSL certification verification errors from
JIRA. Some people have self-hosted JIRA instances with self-signed SSL
certificates. In those cases, it can be nice to have an option to ignore
the verification errors.
